### PR TITLE
Wire valuation engine into ingestion pipeline

### DIFF
--- a/ingestion/src/ingestion/database.py
+++ b/ingestion/src/ingestion/database.py
@@ -55,12 +55,7 @@ class SupabaseRepository:
             Listing data as dict, or None if not found
         """
         try:
-            response = (
-                self.client.table("listings")
-                .select("*")
-                .eq("listing_id", listing_id)
-                .execute()
-            )
+            response = self.client.table("listings").select("*").eq("listing_id", listing_id).execute()
             if response.data:
                 return response.data[0]
             return None
@@ -82,11 +77,7 @@ class SupabaseRepository:
         listing_data = self._listing_to_dict(listing)
 
         try:
-            response = (
-                self.client.table("listings")
-                .upsert(listing_data, on_conflict="listing_id")
-                .execute()
-            )
+            response = self.client.table("listings").upsert(listing_data, on_conflict="listing_id").execute()
             return response.data[0] if response.data else listing_data
         except Exception as e:
             print(f"Error upserting listing {listing.listing_id}: {e}")
@@ -102,6 +93,7 @@ class SupabaseRepository:
         Returns:
             Dictionary representation
         """
+
         # Convert Decimal to string for JSON serialization
         def decimal_to_str(value):
             return str(value) if value is not None else None
@@ -143,6 +135,12 @@ class SupabaseRepository:
                 }
                 for ah in listing.auction_history
             ],
+            "estimated_price": decimal_to_str(listing.estimated_price),
+            "undervalue_score": listing.undervalue_score,
+            "valuation_classification": (
+                listing.valuation_classification.value if listing.valuation_classification else None
+            ),
+            "distress_signal": listing.distress_signal,
             "created_at": datetime_to_str(listing.created_at) or datetime.utcnow().isoformat(),
             "updated_at": datetime.utcnow().isoformat(),
         }
@@ -171,9 +169,7 @@ class SupabaseRepository:
             print(f"Error adding event: {e}")
             raise
 
-    def get_listing_events(
-        self, listing_id: str, event_type: Optional[EventType] = None
-    ) -> List[Dict[str, Any]]:
+    def get_listing_events(self, listing_id: str, event_type: Optional[EventType] = None) -> List[Dict[str, Any]]:
         """
         Get events for a listing.
 
@@ -217,4 +213,3 @@ class SupabaseRepository:
         except Exception as e:
             print(f"Error fetching listings: {e}")
             return []
-

--- a/ingestion/src/ingestion/ingester.py
+++ b/ingestion/src/ingestion/ingester.py
@@ -17,6 +17,7 @@ models_path = Path(__file__).parent.parent.parent.parent.parent / "models" / "sr
 sys.path.insert(0, str(models_path))
 
 from models import Listing, ListingStatus, EventTimeline, EventType
+from models.valuation import PriceModel, UndervaluationDetector, compute_undervalue_score
 
 from .database import SupabaseRepository
 from .readers import RealestateReader, DomainReader, detect_reader_type
@@ -46,6 +47,8 @@ class Ingester:
         self,
         repository: SupabaseRepository,
         distress_window_days: int = _DEFAULT_DISTRESS_WINDOW_DAYS,
+        price_model: Optional[PriceModel] = None,
+        undervaluation_detector: Optional[UndervaluationDetector] = None,
     ) -> None:
         """
         Initialize ingester with database repository.
@@ -53,10 +56,19 @@ class Ingester:
         Args:
             repository: SupabaseRepository instance
             distress_window_days: Window (days) for DISTRESS_SIGNAL compound detection (M3-3).
+            price_model: Optional PriceModel for baseline valuation (M2-1).
+                         Defaults to a PriceModel loaded from the bundled seed file.
+            undervaluation_detector: Optional UndervaluationDetector for emitting
+                                     UNDERVALUED_THRESHOLD_CROSSED events (M2-3).
+                                     Defaults to the 10% threshold.
         """
         self.repository = repository
         self.event_timeline = EventTimeline()
         self.distress_window_days = distress_window_days
+        self.price_model = price_model if price_model is not None else PriceModel()
+        self.undervaluation_detector = (
+            undervaluation_detector if undervaluation_detector is not None else UndervaluationDetector()
+        )
         self.stats = {
             "processed": 0,
             "created": 0,
@@ -150,6 +162,11 @@ class Ingester:
         # Get existing listing from database
         existing = self.repository.get_listing(listing.listing_id)
 
+        # M2-1 / M2-2 / M2-3: compute estimated price, undervalue score, and
+        # emit UNDERVALUED_THRESHOLD_CROSSED event on state change.  Done before
+        # upsert so the valuation fields are persisted in the same write.
+        self._compute_valuation(listing)
+
         if existing:
             # Update existing listing with change detection
             self._update_listing(listing, existing)
@@ -162,6 +179,43 @@ class Ingester:
         # Save events to database
         self._save_events(listing.listing_id)
 
+    def _compute_valuation(self, listing: Listing) -> None:
+        """
+        Populate ``estimated_price``, ``undervalue_score``, and
+        ``valuation_classification`` on the listing, and emit an
+        ``UNDERVALUED_THRESHOLD_CROSSED`` event when the listing newly crosses
+        the threshold (state-change only — handled by UndervaluationDetector).
+
+        Recomputed on every ingest so that changes to the seed median data, the
+        listed price, or any valuation input produce up-to-date results.
+
+        Skips scoring (but still sets estimated_price) when ``current_price``
+        is missing — the score is undefined without an asking price.
+        """
+        estimated = self.price_model.estimate(
+            suburb=listing.suburb,
+            property_type=listing.property_type,
+            bedrooms=listing.bedrooms,
+        )
+        listing.estimated_price = estimated
+
+        if listing.current_price is None or listing.current_price <= 0:
+            listing.undervalue_score = None
+            listing.valuation_classification = None
+            return
+
+        result = compute_undervalue_score(
+            listing_id=listing.listing_id,
+            listed_price=listing.current_price,
+            estimated_price=estimated,
+        )
+        listing.undervalue_score = result.undervalue_score
+        listing.valuation_classification = result.classification
+
+        fired = self.undervaluation_detector.check(result, self.event_timeline)
+        if fired:
+            self.stats["events_generated"] += 1
+
     def _update_listing(self, new_listing: Listing, existing: Dict) -> None:
         """
         Update existing listing with change detection.
@@ -171,11 +225,7 @@ class Ingester:
             existing: Existing listing data from database
         """
         # Detect price changes
-        existing_price = (
-            Decimal(str(existing.get("current_price")))
-            if existing.get("current_price")
-            else None
-        )
+        existing_price = Decimal(str(existing.get("current_price"))) if existing.get("current_price") else None
         new_price = new_listing.current_price
 
         if existing_price and new_price and new_price < existing_price:
@@ -197,11 +247,7 @@ class Ingester:
 
         # Detect auction rescheduling and cancellation via auction_datetime change
         existing_auction = existing.get("auction_datetime")
-        new_auction = (
-            new_listing.auction_datetime.isoformat()
-            if new_listing.auction_datetime
-            else None
-        )
+        new_auction = new_listing.auction_datetime.isoformat() if new_listing.auction_datetime else None
 
         # M3-1: auction_datetime was set and is now None/removed → AUCTION_CANCELLED
         # (Covers the case where the status field alone does not change but the
@@ -383,15 +429,10 @@ class Ingester:
 
         for event in events:
             # Check if event already exists (idempotency)
-            existing_events = self.repository.get_listing_events(
-                listing_id, event.event_type
-            )
+            existing_events = self.repository.get_listing_events(listing_id, event.event_type)
 
             # Simple check: if event with same type and timestamp exists, skip
-            event_exists = any(
-                e.get("timestamp") == event.timestamp.isoformat()
-                for e in existing_events
-            )
+            event_exists = any(e.get("timestamp") == event.timestamp.isoformat() for e in existing_events)
 
             if not event_exists:
                 self.repository.add_event(event)
@@ -414,4 +455,3 @@ class Ingester:
             "events_generated": 0,
             "errors": 0,
         }
-

--- a/ingestion/src/ingestion/ingester.py
+++ b/ingestion/src/ingestion/ingester.py
@@ -204,11 +204,27 @@ class Ingester:
             listing.valuation_classification = None
             return
 
-        result = compute_undervalue_score(
-            listing_id=listing.listing_id,
-            listed_price=listing.current_price,
-            estimated_price=estimated,
-        )
+        # compute_undervalue_score raises ValueError when estimated_price <= 0
+        # (e.g. SUBURB_MEDIANS_PATH points at a bad seed file with a zeroed
+        # entry).  Don't let seed-data issues abort ingestion for the listing.
+        try:
+            result = compute_undervalue_score(
+                listing_id=listing.listing_id,
+                listed_price=listing.current_price,
+                estimated_price=estimated,
+            )
+        except ValueError:
+            log.exception(
+                "Failed to compute undervalue score for %s (current_price=%s, estimated_price=%s); "
+                "leaving undervalue fields unset",
+                listing.listing_id,
+                listing.current_price,
+                estimated,
+            )
+            listing.undervalue_score = None
+            listing.valuation_classification = None
+            return
+
         listing.undervalue_score = result.undervalue_score
         listing.valuation_classification = result.classification
 

--- a/ingestion/tests/test_valuation_integration.py
+++ b/ingestion/tests/test_valuation_integration.py
@@ -1,0 +1,304 @@
+"""
+Integration tests for the valuation engine wiring inside the Ingester.
+
+Covers backlog items #1, #2, #3:
+- #1 Baseline estimated price model — estimated_price is computed and persisted
+- #2 Compare estimated price vs listing price — undervalue_score + classification
+     are computed and persisted
+- #3 Undervaluation threshold detection — UNDERVALUED_THRESHOLD_CROSSED event
+     is emitted once on state change, not on every ingest
+
+All tests use an in-memory mock repository — no Supabase credentials required.
+"""
+
+from __future__ import annotations
+
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+# Path wiring — mirrors test_pipeline.py
+_repo_root = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+sys.path.insert(0, str(_repo_root / "models" / "src"))
+
+from ingestion.ingester import Ingester  # noqa: E402
+from models import EventType, ListingStatus, PropertyType  # noqa: E402
+from models.address import Address  # noqa: E402
+from models.listing import Listing  # noqa: E402
+from models.valuation import PriceModel, UndervaluationDetector  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_repo(existing: Dict[str, Any] | None = None) -> MagicMock:
+    repo = MagicMock()
+    repo.get_listing.return_value = existing
+    repo.upsert_listing.return_value = {}
+    repo.get_listing_events.return_value = []
+    repo.add_event.return_value = {}
+    return repo
+
+
+def _make_listing(
+    listing_id: str = "L1",
+    suburb: str = "Testville",
+    property_type: PropertyType = PropertyType.HOUSE,
+    bedrooms: int = 3,
+    current_price: Decimal | None = Decimal("700000"),
+) -> Listing:
+    return Listing(
+        listing_id=listing_id,
+        address=Address(
+            street_number="1",
+            street_name="Example St",
+            suburb=suburb,
+            state="Vic",
+            postcode="3000",
+            full_address=f"1 Example St, {suburb}, Vic 3000",
+        ),
+        suburb=suburb,
+        property_type=property_type,
+        bedrooms=bedrooms,
+        status=ListingStatus.UNKNOWN,
+        current_price=current_price,
+    )
+
+
+def _tiny_price_model(tmp_path: Path, median: int = 1_000_000) -> PriceModel:
+    """Build a PriceModel from a minimal seed file with a controllable median."""
+    import json
+
+    data = {
+        "suburb_medians": {"Testville": median},
+        "bedroom_weights": {
+            "1": 0.65,
+            "2": 0.82,
+            "3": 1.00,
+            "4": 1.18,
+            "5": 1.34,
+            "6": 1.48,
+            "default": 1.00,
+        },
+        "property_type_multipliers": {
+            "house": 1.00,
+            "unit": 0.72,
+            "apartment": 0.72,
+            "townhouse": 0.88,
+            "villa": 0.85,
+            "studio": 0.55,
+            "land": 0.60,
+            "other": 0.90,
+            "default": 1.00,
+        },
+        "fallback_median": 800_000,
+    }
+    p = tmp_path / "medians.json"
+    p.write_text(json.dumps(data))
+    return PriceModel(medians_path=p)
+
+
+def _captured_upsert_payloads(repo: MagicMock) -> List[Listing]:
+    """Return the Listing objects passed to repo.upsert_listing, in call order."""
+    return [call.args[0] for call in repo.upsert_listing.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# #1: estimated_price computed and populated
+# ---------------------------------------------------------------------------
+
+
+class TestEstimatedPricePopulated:
+    def test_new_listing_has_estimated_price(self, tmp_path: Path) -> None:
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing = _make_listing(current_price=Decimal("700000"))
+        ingester._ingest_listing(listing)
+
+        # 3-bed house in Testville → median × 1.0 × 1.0 = 1 000 000
+        assert listing.estimated_price == Decimal("1000000")
+
+        payloads = _captured_upsert_payloads(repo)
+        assert payloads, "upsert_listing must be called"
+        assert payloads[0].estimated_price == Decimal("1000000")
+
+    def test_unit_applies_property_type_multiplier(self, tmp_path: Path) -> None:
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing = _make_listing(property_type=PropertyType.UNIT, current_price=Decimal("600000"))
+        ingester._ingest_listing(listing)
+        # 1 000 000 × 1.0 × 0.72 = 720 000
+        assert listing.estimated_price == Decimal("720000")
+
+    def test_recomputed_on_update(self, tmp_path: Path) -> None:
+        """When a listing is updated, estimated_price is recomputed (data-change AC)."""
+        repo = _make_mock_repo(
+            existing={
+                "listing_id": "L1",
+                "current_price": "900000",
+                "status": "unknown",
+                "auction_datetime": None,
+            }
+        )
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing = _make_listing(current_price=Decimal("700000"))
+        # Stale estimate on the incoming listing — must be overwritten
+        listing.estimated_price = Decimal("1")
+        ingester._ingest_listing(listing)
+        assert listing.estimated_price == Decimal("1000000")
+
+
+# ---------------------------------------------------------------------------
+# #2: undervalue score + classification populated
+# ---------------------------------------------------------------------------
+
+
+class TestUndervalueScorePopulated:
+    def test_score_and_classification_set(self, tmp_path: Path) -> None:
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        # Listed 700k vs estimated 1M → 30% below → significantly undervalued
+        listing = _make_listing(current_price=Decimal("700000"))
+        ingester._ingest_listing(listing)
+
+        assert listing.undervalue_score == pytest.approx(30.0, abs=0.01)
+        assert listing.valuation_classification is not None
+        assert listing.valuation_classification.value == "significantly_undervalued"
+
+    def test_fair_value_when_close_to_estimate(self, tmp_path: Path) -> None:
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing = _make_listing(current_price=Decimal("980000"))  # 2% below
+        ingester._ingest_listing(listing)
+        assert listing.valuation_classification.value == "fair_value"
+
+    def test_overpriced_produces_negative_score(self, tmp_path: Path) -> None:
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing = _make_listing(current_price=Decimal("1200000"))  # 20% above
+        ingester._ingest_listing(listing)
+        assert listing.undervalue_score < 0
+        assert listing.valuation_classification.value == "overpriced"
+
+    def test_no_current_price_yields_no_score(self, tmp_path: Path) -> None:
+        """estimated_price is still set, but score is undefined without a listed price."""
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing = _make_listing(current_price=None)
+        ingester._ingest_listing(listing)
+
+        assert listing.estimated_price == Decimal("1000000")
+        assert listing.undervalue_score is None
+        assert listing.valuation_classification is None
+
+
+# ---------------------------------------------------------------------------
+# #3: UNDERVALUED_THRESHOLD_CROSSED event emitted on state change only
+# ---------------------------------------------------------------------------
+
+
+class TestUndervaluedThresholdEvent:
+    def test_event_emitted_when_newly_undervalued(self, tmp_path: Path) -> None:
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+            undervaluation_detector=UndervaluationDetector(threshold_pct=10.0),
+        )
+        listing = _make_listing(current_price=Decimal("700000"))  # 30% undervalued
+        ingester._ingest_listing(listing)
+
+        events = ingester.event_timeline.get_events_for_listing("L1")
+        assert any(e.event_type == EventType.UNDERVALUED_THRESHOLD_CROSSED for e in events)
+
+    def test_no_event_for_fair_value_listing(self, tmp_path: Path) -> None:
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing = _make_listing(current_price=Decimal("980000"))  # 2% below
+        ingester._ingest_listing(listing)
+
+        events = ingester.event_timeline.get_events_for_listing("L1")
+        assert not any(e.event_type == EventType.UNDERVALUED_THRESHOLD_CROSSED for e in events)
+
+    def test_event_not_duplicated_on_second_ingest(self, tmp_path: Path) -> None:
+        """Second ingest of an already-undervalued listing must not re-emit the event."""
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=1_000_000),
+        )
+        listing1 = _make_listing(current_price=Decimal("700000"))
+        ingester._ingest_listing(listing1)
+
+        # Simulate second ingestion round (detector keeps in-memory state)
+        repo.get_listing.return_value = {
+            "listing_id": "L1",
+            "current_price": "700000",
+            "status": "unknown",
+            "auction_datetime": None,
+        }
+        listing2 = _make_listing(current_price=Decimal("700000"))
+        ingester._ingest_listing(listing2)
+
+        events = ingester.event_timeline.get_events_for_listing("L1")
+        crossed = [e for e in events if e.event_type == EventType.UNDERVALUED_THRESHOLD_CROSSED]
+        assert len(crossed) == 1
+
+
+# ---------------------------------------------------------------------------
+# Persistence: valuation fields are included in the upsert payload
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_valuation_fields_serialised_via_database_helper(self, tmp_path: Path) -> None:
+        """The _listing_to_dict helper must include the valuation fields for DB write."""
+        from ingestion.database import SupabaseRepository
+
+        # Build a listing with valuation fields populated — no network calls needed
+        # because _listing_to_dict is a pure serialiser.
+        listing = _make_listing(current_price=Decimal("700000"))
+        listing.estimated_price = Decimal("1000000")
+        listing.undervalue_score = 30.0
+        from models.enums import ValuationClassification
+
+        listing.valuation_classification = ValuationClassification.SIGNIFICANTLY_UNDERVALUED
+
+        # Bypass __init__ (which creates a real Supabase client) — we only need
+        # the unbound method behaviour.
+        data = SupabaseRepository._listing_to_dict(SupabaseRepository.__new__(SupabaseRepository), listing)
+
+        assert data["estimated_price"] == "1000000"
+        assert data["undervalue_score"] == 30.0
+        assert data["valuation_classification"] == "significantly_undervalued"
+        assert data["distress_signal"] is False

--- a/ingestion/tests/test_valuation_integration.py
+++ b/ingestion/tests/test_valuation_integration.py
@@ -218,6 +218,21 @@ class TestUndervalueScorePopulated:
         assert listing.undervalue_score is None
         assert listing.valuation_classification is None
 
+    def test_zero_estimated_price_does_not_abort_ingest(self, tmp_path: Path) -> None:
+        """Bad seed data (zero median) → upsert still happens, valuation fields None."""
+        repo = _make_mock_repo(existing=None)
+        ingester = Ingester(
+            repo,
+            price_model=_tiny_price_model(tmp_path, median=0),  # pathological seed
+        )
+        listing = _make_listing(current_price=Decimal("700000"))
+        ingester._ingest_listing(listing)
+
+        assert listing.estimated_price == Decimal("0")
+        assert listing.undervalue_score is None
+        assert listing.valuation_classification is None
+        assert repo.upsert_listing.called
+
 
 # ---------------------------------------------------------------------------
 # #3: UNDERVALUED_THRESHOLD_CROSSED event emitted on state change only


### PR DESCRIPTION
## Summary

The `PriceModel`, `compute_undervalue_score`, and `UndervaluationDetector` were already implemented in `models/valuation.py`, and the Supabase schema had the `estimated_price` / `undervalue_score` / `valuation_classification` / `distress_signal` columns — but nothing in the ingestion pipeline actually invoked the valuation engine or wrote those fields.

This PR wires them together:

- **`Ingester.__init__`** — instantiates `PriceModel` and `UndervaluationDetector` (both injectable for tests).
- **`Ingester._compute_valuation`** — new helper invoked from `_ingest_listing` *before* upsert. Computes the estimated price, sets the undervalue score + classification, and asks the detector to emit `UNDERVALUED_THRESHOLD_CROSSED` only on a state change.
- **`SupabaseRepository._listing_to_dict`** — now serialises `estimated_price`, `undervalue_score`, `valuation_classification`, and `distress_signal` so they actually reach Supabase.

Re-running an ingest with unchanged data no longer emits a duplicate threshold-crossed event (detector holds in-memory state). If the seed medians, listed price, or any valuation input change between runs, the score is recomputed on the next ingest.

Closes #1, #2, #3.

## Test plan

- [x] 11 new tests in `ingestion/tests/test_valuation_integration.py` cover:
  - `estimated_price` populated on new/update, property-type multiplier applied
  - `undervalue_score` + `valuation_classification` set correctly (undervalued / fair / overpriced)
  - No score when `current_price` is missing
  - `UNDERVALUED_THRESHOLD_CROSSED` emitted on first crossing, *not* on second consecutive ingest
  - `_listing_to_dict` serialises the valuation fields
- [x] Full ingestion suite passes (46 tests)
- [x] No new lint errors introduced (pre-existing E402/F401 from `sys.path.insert` pattern unchanged)
- [ ] Verify on real Supabase once deployed (needs credentials)

https://claude.ai/code/session_01Vk2LGMoAiUemEWozkZi13h

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk2LGMoAiUemEWozkZi13h)_